### PR TITLE
Update to Denizen 1.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
+sourceCompatibility = 11
+targetCompatibility = 11
+
 repositories {
 	mavenCentral()
     maven {
@@ -11,7 +14,7 @@ repositories {
 dependencies {
     compileOnly "org.spigotmc:spigot-1.16.5:+"
     compileOnly "io.lumine.xikage:mythicmobs:+"
-	compileOnly "com.denizenscript:denizen:+"
+	compileOnly fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 11
-targetCompatibility = 11
-
 repositories {
 	mavenCentral()
     maven {

--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,18 @@ targetCompatibility = 11
 repositories {
 	mavenCentral()
     maven {
+        url "https://repo.citizensnpcs.co/"
+    }
+    maven {
         url "http://mc.hackerzlair.org:8888/repository/public"
+
     }
 }
 
 dependencies {
     compileOnly "org.spigotmc:spigot-1.16.5:+"
     compileOnly "io.lumine.xikage:mythicmobs:+"
-	compileOnly fileTree(dir: 'libs', include: ['*.jar'])
+	compileOnly "com.denizenscript:denizen:1.2.0-SNAPSHOT"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 #Wed Mar 03 13:24:31 CET 2021
-artver=0.605-SNAPSHOT
-artbuild=618
+artver=0.606-SNAPSHOT
+artbuild=619

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Denizen Support for MythicMobs 4.11
 
 # [DOWNLOAD](https://mc.hackerzlair.org/jenkins/job/MythicDenizenAddon/) [![Build Status](https://mc.hackerzlair.org/jenkins/job/MythicDenizenAddon/badge/icon)] <br>
-
+- Update 0.605  - MythicMobs 4.11.0 free, Denizen 1.2.0 & Spigot 1.16.5 support (testing needed!)
 - Update 0.605  - MythicMobs 4.11.0 free, Denizen 1.1.9 & Spigot 1.16.5 support
 - Update 0.604  - MythicMobs 4.11.0 free, Denizen 1.1.8 & Spigot 1.16.4 support
 - Update 0.603  - MythicMobs 4.10.0 free, Denizen 1.1.7 & Spigot 1.16.3 support

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/Utils.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/Utils.java
@@ -90,12 +90,10 @@ Utils
 		}
 		
 		if(entries!=null) {
-			String id=ScriptQueue.getNextId(script.getContainer().getName());
-
 			HashMap<String,ObjectTag>context=new HashMap<String,ObjectTag>();
 			context.put("data",new dMythicMeta(data));
 			
-			ScriptQueue queue=InstantQueue.getQueue(id).addEntries(entries);
+			ScriptQueue queue= new InstantQueue(script.getContainer().getName()).addEntries(entries);
 			queue.setContextSource(new MythicContextSource(context));
 			for(Map.Entry<String,String>item:attributes.entrySet()) {
 				queue.addDefinition(item.getKey(),item.getValue());

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/GetMythicSkills.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/GetMythicSkills.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.objects.Argument;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.gmail.berndivader.mythicdenizenaddon.MythicMobsAddon;
@@ -42,7 +43,7 @@ AbstractCommand
 	@Override
 	public void execute(ScriptEntry entry) {
 		Pattern p=Pattern.compile(entry.getElement(Statics.str_filter).asString());
-		String metaId=entry.hasObject(Statics.str_data)?entry.getObjectTag(Statics.str_data).identify():null;
+		String metaId = (entry.hasObject(Statics.str_data))?((ObjectTag)entry.getObjectTag(Statics.str_data)).identify():null;
 		if (!entry.getElement(Statics.str_strict).asBoolean()) {
 			Iterator<Skill>it=MythicMobsAddon.mythicmobs.getSkillManager().getSkills().iterator();
 			ListTag list=new ListTag();

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/MythicMobsSpawn.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/MythicMobsSpawn.java
@@ -55,7 +55,7 @@ AbstractCommand
 			System.err.println("No MythicMobType found!");
 		}
 		int level = entry.getElement(Statics.str_level).asInt();
-		LocationTag loc = entry.getObjectTag(Statics.str_location);
+		LocationTag loc = entry.<LocationTag>getObjectTag(Statics.str_location);
 		String worldName = entry.hasObject(Statics.str_world)?entry.getElement(Statics.str_world).asString():loc.getWorld().getName();
 		AbstractLocation location = BukkitAdapter.adapt(loc);
 		AbstractWorld world = BukkitAdapter.adapt(Bukkit.getServer().getWorld(worldName));

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/TransformToMythicMob.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/TransformToMythicMob.java
@@ -39,7 +39,7 @@ AbstractCommand
 	
 	@Override
 	public void execute(ScriptEntry entry) {
-		Entity entity = ((EntityTag)entry.getObjectTag(Statics.str_entity)).getBukkitEntity();
+		Entity entity = ((EntityTag)entry.<EntityTag>getObjectTag(Statics.str_entity)).getBukkitEntity();
 		String mmName = entry.getElement(Statics.str_mobtype).asString();
 		MythicMob mm = MythicMobsAddon.mythicmobs.getMobManager().getMythicMob(mmName);
 		int level = entry.getElement(Statics.str_level).asInt();

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/TriggerSkill.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/cmds/TriggerSkill.java
@@ -49,6 +49,6 @@ AbstractCommand
 		}
 		ActiveMob am = ((dActiveMob)entry.getObject(Statics.str_activemob)).getActiveMob();
 		AbstractEntity ae = BukkitAdapter.adapt(((EntityTag)entry.getObject(Statics.str_entity)).getBukkitEntity());
-		new TriggeredSkill(trigger,am,ae,new Pair[0]);
+		new TriggeredSkill(trigger,am,ae,false);
 	}
 }

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/conditions/ScriptCondition.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/conditions/ScriptCondition.java
@@ -62,13 +62,11 @@ AbstractCustomCondition
 		}
 		
 		if(entries!=null) {
-			String id=ScriptQueue.getNextId(script.getContainer().getName());
-
 			HashMap<String,ObjectTag>context=new HashMap<String,ObjectTag>();
 			context.put("source",denizen_source);
 			if(denizen_target!=null) context.put("target",denizen_target);
 			
-			ScriptQueue queue=InstantQueue.getQueue(id).addEntries(entries);
+			ScriptQueue queue= new InstantQueue(script.getContainer().getName()).addEntries(entries);
 			queue.setContextSource(new MythicContextSource(context));
 			for(Map.Entry<String,String>item:attributes.entrySet()) {
 				queue.addDefinition(item.getKey(),item.getValue());
@@ -83,8 +81,8 @@ AbstractCustomCondition
 			});
 			queue.start();
 			
-			Object o=queue.getLastEntryExecuted().getArguments();
-			if(o!=null&&o instanceof List) {
+			List<String> o=queue.getLastEntryExecuted().getArguments();
+			if(o!=null) {
 				for(String s1:(List<String>)o) {
 					Argument arg=new Argument(s1);
 					if(arg.matchesBoolean()) {

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/drops/DenizenScriptDrop.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/drops/DenizenScriptDrop.java
@@ -61,12 +61,11 @@ IIntangibleDrop
 		
 		if(entries!=null) {
 			ScriptQueue queue;
-			String id=ScriptQueue.getNextId(script.getContainer().getName());
 			if(script.getContainer().contains("SPEED")) {
-				long ticks=DurationTag.valueOf(script.getContainer().getString("SPEED","0")).getTicks();
-				queue=ticks>0?((TimedQueue)TimedQueue.getExistingQueue(id).addEntries(entries)).setSpeed(ticks):InstantQueue.getQueue(id).addEntries(entries);
+				long ticks=DurationTag.valueOf(script.getContainer().getString("SPEED","0"), null).getTicks();
+				queue=ticks>0?((TimedQueue)(new TimedQueue(script.getContainer().getName()).addEntries(entries))).setSpeed(ticks):new InstantQueue(script.getContainer().getName()).addEntries(entries);
 			} else {
-				queue=TimedQueue.getExistingQueue(id).addEntries(entries);
+				queue=new TimedQueue(script.getContainer().getName()).addEntries(entries);
 			}
 			HashMap<String,ObjectTag>context=new HashMap<String,ObjectTag>();
 			context.put("player",new PlayerTag((Player)abstract_player.getBukkitEntity()));

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/events/DMechanicEvent.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/events/DMechanicEvent.java
@@ -23,7 +23,7 @@ INoTargetSkill {
 	public DMechanicEvent(String skill, MythicLineConfig mlc) {
 		super(skill, mlc);
 		
-		this.ASYNC_SAFE=false;
+		this.threadSafetyLevel = ThreadSafetyLevel.EITHER;
 		this.skill = mlc.getString(new String[]{"skill", "s"}, "");
 		this.args = mlc.getString(new String[]{"args", "arg", "a"},"");
 	}

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/mechanics/DenizenScriptMechanic.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/mechanics/DenizenScriptMechanic.java
@@ -43,7 +43,7 @@ ITargetedEntitySkill
 
 	public DenizenScriptMechanic(String skill, MythicLineConfig mlc) {
 		super(skill, mlc);
-		this.ASYNC_SAFE=false;
+		this.threadSafetyLevel = ThreadSafetyLevel.EITHER;;
 		
 		script_name=config.getString("script","");
 		attributes=Utils.parse_attributes(skill);

--- a/src/main/java/com/gmail/berndivader/mythicdenizenaddon/mechanics/DenizenScriptMechanic.java
+++ b/src/main/java/com/gmail/berndivader/mythicdenizenaddon/mechanics/DenizenScriptMechanic.java
@@ -79,12 +79,11 @@ ITargetedEntitySkill
 		}
 		if(entries==null) return false;
 		ScriptQueue queue;
-		String id=ScriptQueue.getNextId(script.getContainer().getName());
 		if(script.getContainer().contains("SPEED")) {
 			long ticks=DurationTag.valueOf(script.getContainer().getString("SPEED","0")).getTicks();
-			queue=ticks>0?((TimedQueue)TimedQueue.getExistingQueue(id).addEntries(entries)).setSpeed(ticks):InstantQueue.getQueue(id).addEntries(entries);
+			queue=ticks>0?((TimedQueue)(new TimedQueue(script.getContainer().getName()).addEntries(entries))).setSpeed(ticks):new InstantQueue(script.getContainer().getName()).addEntries(entries);
 		} else {
-			queue=TimedQueue.getExistingQueue(id).addEntries(entries);
+			queue=new TimedQueue(script.getContainer().getName()).addEntries(entries);
 		}
 		HashMap<String,ObjectTag>context=new HashMap<String,ObjectTag>();
 		context.put("data",new dMythicMeta(data));


### PR DESCRIPTION
This PR is a successful build compatible with Denizen 1.2.0 changes addressed in #12. In-game testing still required.

Maven repository "https://repo.citizensnpcs.co/" was added to gradle.build as it contains 1.2.0 version. This fixes getObjectTag method not found.

All ScriptQueue code was updated in compliance with new id generation (or at least I hope so).